### PR TITLE
Rename to Bun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-elixir_bun-*.tar
+bun-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in dev:
 ```elixir
 def deps do
   [
-    {:elixir_bun, "~> 0.1", runtime: Mix.env() == :dev}
+    {:bun, "~> 0.1", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -27,7 +27,7 @@ then it only needs to be a dev dependency:
 ```elixir
 def deps do
   [
-    {:elixir_bun, "~> 0.1", only: :dev}
+    {:bun, "~> 0.1", only: :dev}
   ]
 end
 ```
@@ -36,7 +36,7 @@ Once installed, change your `config/config.exs` to pick your
 bun version of choice:
 
 ```elixir
-config :elixir_bun, version: "1.0.7"
+config :bun, version: "1.0.7"
 ```
 
 Now you can install bun by running:
@@ -70,7 +70,7 @@ directory, the OS environment, and default arguments to the
 `bun` task:
 
 ```elixir
-config :elixir_bun,
+config :bun,
   version: "1.0.7",
   default: [
     args: ~w(build js/app.js),
@@ -93,7 +93,7 @@ First add it as a dependency in your `mix.exs`:
 def deps do
   [
     {:phoenix, github: "phoenixframework/phoenix"},
-    {:elixir_bun, "~> 0.1", runtime: Mix.env() == :dev}
+    {:bun, "~> 0.1", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -102,7 +102,7 @@ Now let's change `config/config.exs` to configure `bun` to use
 `assets/js/app.js` as an entry point and write to `priv/static/assets`:
 
 ```elixir
-config :elixir_bun,
+config :bun,
   version: "1.0.7",
   default: [
     args: ~w(build js/app.js --outdir=../priv/static/assets --external /fonts/* --external /images/*),
@@ -184,4 +184,4 @@ import "../css/app.css"
 
 Copyright (c) 2023 Cristian Álvarez.
 
-elixir_bun source code is licensed under the [MIT License](LICENSE.md).
+bun source code is licensed under the [MIT License](LICENSE.md).

--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -10,7 +10,7 @@ defmodule Bun do
   profile called `:default` which you can configure its args, current
   directory and environment:
 
-      config :elixir_bun,
+      config :bun,
         version: "#{@latest_version}",
         default: [
           args: ~w(build js/app.js  --outdir=../priv/static/assets),
@@ -40,7 +40,7 @@ defmodule Bun do
   `MIX_BUN_PATH` environment variable, which you can then read in
   your configuration file:
 
-      config :elixir_bun, path: System.get_env("MIX_BUN_PATH")
+      config :bun, path: System.get_env("MIX_BUN_PATH")
 
   """
 
@@ -49,11 +49,11 @@ defmodule Bun do
 
   @doc false
   def start(_, _) do
-    unless Application.get_env(:elixir_bun, :version) do
+    unless Application.get_env(:bun, :version) do
       Logger.warning("""
       bun version is not configured. Please set it in your config files:
 
-          config :elixir_bun, :version, "#{latest_version()}"
+          config :bun, :version, "#{latest_version()}"
       """)
     end
 
@@ -84,7 +84,7 @@ defmodule Bun do
   Returns the configured bun version.
   """
   def configured_version do
-    Application.get_env(:elixir_bun, :version, latest_version())
+    Application.get_env(:bun, :version, latest_version())
   end
 
   @doc """
@@ -93,11 +93,11 @@ defmodule Bun do
   Returns nil if the profile does not exist.
   """
   def config_for!(profile) when is_atom(profile) do
-    Application.get_env(:elixir_bun, profile) ||
+    Application.get_env(:bun, profile) ||
       raise ArgumentError, """
       unknown bun profile. Make sure the profile is defined in your config/config.exs file, such as:
 
-          config :elixir_bun,
+          config :bun,
             #{profile}: [
               args: ~w(js/app.js --outdir=../priv/static/assets),
               cd: Path.expand("../assets", __DIR__),
@@ -114,7 +114,7 @@ defmodule Bun do
   def bin_path do
     name = "bun"
 
-    Application.get_env(:elixir_bun, :path) ||
+    Application.get_env(:bun, :path) ||
       if Code.ensure_loaded?(Mix.Project) do
         Path.join(Path.dirname(Mix.Project.build_path()), name)
       else
@@ -164,7 +164,7 @@ defmodule Bun do
     # If we launch the bun process directly, it will keep running as a zombie process even after
     # closing the parent Elixir process. To avoid this issue we wrap the application in a script
     # that checks for stdin to ensure bun is closed.
-    watcher_path = Path.join(:code.priv_dir(:elixir_bun), "bun_launcher.sh")
+    watcher_path = Path.join(:code.priv_dir(:bun), "bun_launcher.sh")
 
     watcher_path
     |> System.cmd([bin_path()] ++ args ++ extra_args, opts)
@@ -282,7 +282,7 @@ defmodule Bun do
         couldn't fetch #{url}: #{inspect(other)}
 
         You may also install the "bun" executable manually, \
-        see the docs: https://hexdocs.pm/elixir_bun
+        see the docs: https://hexdocs.pm/bun
         """
     end
   end

--- a/lib/mix/tasks/bun.ex
+++ b/lib/mix/tasks/bun.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Bun do
     if opts[:runtime_config] do
       Mix.Task.run("app.config")
     else
-      Application.ensure_all_started(:elixir_bun)
+      Application.ensure_all_started(:bun)
     end
 
     Mix.Task.reenable("bun")

--- a/lib/mix/tasks/bun.install.ex
+++ b/lib/mix/tasks/bun.install.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Bun.Install do
   By default, it installs #{Bun.latest_version()} but you
   can configure it in your config files, such as:
 
-      config :elixir_bun, :version, "#{Bun.latest_version()}"
+      config :bun, :version, "#{Bun.latest_version()}"
 
   ## Options
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,11 +2,11 @@ defmodule ElixirBun.MixProject do
   use Mix.Project
 
   @version "0.1.4"
-  @source_url "https://github.com/crbelaus/elixir_bun"
+  @source_url "https://github.com/crbelaus/bun"
 
   def project do
     [
-      app: :elixir_bun,
+      app: :bun,
       version: @version,
       elixir: "~> 1.15",
       deps: deps(),


### PR DESCRIPTION
After talking with the [Hex.pm](https://hex.pm) team they said that the've removed the `bun` package as having an empty package that is just squatting on the name violates their rules.

This pull request renames `elixir_bun` to `bun`. This should make it much more discoverable and fix #7 and fix christopherlai/bun#1