### PR TITLE
Rename Bun.MixProject

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule ElixirBun.MixProject do
+defmodule Bun.MixProject do
   use Mix.Project
 
   @version "1.0.0"

--- a/test/elixir_bun_test.exs
+++ b/test/elixir_bun_test.exs
@@ -1,8 +1,8 @@
-defmodule ElixirBunTest do
+defmodule BunTest do
   use ExUnit.Case
-  doctest ElixirBun
+  doctest Bun
 
   test "greets the world" do
-    assert ElixirBun.hello() == :world
+    assert Bun.hello() == :world
   end
 end


### PR DESCRIPTION
There is no point on having `ElixirBun` anymore so I'm renaming the missing reference to `Bun` for consistency.