### PR TITLE
Use Bun 1.0.9

### DIFF
--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -1,6 +1,7 @@
 defmodule Bun do
   # https://github.com/oven-sh/bun/releases
-  @latest_version "1.0.7"
+  @latest_version "1.0.9"
+
   @moduledoc """
   Bun is an installer and runner for [bun](https://bun.sh).
 


### PR DESCRIPTION
Bun 1.0.9 [has been released](https://bun.sh/blog/bun-v1.0.9) yesterday.

This pull request sets Bun 1.0.9 as the default version for new installations.