### PR TITLE
Ensure `:inets` and `:ssl` are available during install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    env:
+      MIX_ENV: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pair:
+              elixir: "1.15"
+              otp: 26
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+
+      - uses: actions/cache@v3
+        with:
+          path: deps
+          key: mix-deps-${{ hashFiles('**/mix.lock') }}
+
+      - run: mix deps.get
+
+      - run: mix format --check-formatted
+
+      - run: mix deps.unlock --check-unused
+
+      - run: mix deps.compile
+
+      - run: mix compile --warnings-as-errors
+
+      - run: mix test --warnings-as-errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changelog
 
-Please see [our GitHub "Releases" page](https://github.com/crbelaus/elixir_bun/releases).
+Please see [our GitHub "Releases" page](https://github.com/crbelaus/bun/releases).

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,9 @@
+import Config
+
+if Mix.env() == :test do
+  config :bun,
+    version: "1.0.26",
+    another: [
+      args: ["--version"]
+    ]
+end

--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -1,6 +1,6 @@
 defmodule Bun do
   # https://github.com/oven-sh/bun/releases
-  @latest_version "1.0.9"
+  @latest_version "1.0.26"
 
   @moduledoc """
   Bun is an installer and runner for [bun](https://bun.sh).

--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -246,8 +246,8 @@ defmodule Bun do
     url = String.to_charlist(url)
     Logger.debug("Downloading bun from #{url}")
 
-    {:ok, _} = Application.ensure_all_started(:inets)
-    {:ok, _} = Application.ensure_all_started(:ssl)
+    Mix.ensure_application!(:inets)
+    Mix.ensure_application!(:ssl)
 
     if proxy = proxy_for_scheme(scheme) do
       %{host: host, port: port} = URI.parse(proxy)

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,9 @@ defmodule Bun.MixProject do
         source_url: @source_url,
         source_ref: "v#{@version}",
         extras: ["CHANGELOG.md"]
+      ],
+      aliases: [
+        test: ["bun.install --if-missing", "test"]
       ]
     ]
   end

--- a/test/bun_test.exs
+++ b/test/bun_test.exs
@@ -1,0 +1,37 @@
+defmodule BunTest do
+  use ExUnit.Case, async: true
+
+  @version Bun.latest_version()
+
+  test "run on default" do
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             assert Bun.run(:default, ["--version"]) == 0
+           end) =~ @version
+  end
+
+  test "run on profile" do
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             assert Bun.run(:another, []) == 0
+           end) =~ @version
+  end
+
+  test "updates on install" do
+    Application.put_env(:bun, :version, "1.0.0")
+
+    Mix.Task.rerun("bun.install", ["--if-missing"])
+
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             assert Bun.run(:default, ["--version"]) == 0
+           end) =~ "1.0.0"
+
+    Application.delete_env(:bun, :version)
+
+    Mix.Task.rerun("bun.install", ["--if-missing"])
+
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             assert Bun.run(:default, ["--version"]) == 0
+           end) =~ @version
+  after
+    Application.delete_env(:bun, :version)
+  end
+end

--- a/test/elixir_bun_test.exs
+++ b/test/elixir_bun_test.exs
@@ -1,8 +1,0 @@
-defmodule BunTest do
-  use ExUnit.Case
-  doctest Bun
-
-  test "greets the world" do
-    assert Bun.hello() == :world
-  end
-end


### PR DESCRIPTION
Based on https://github.com/phoenixframework/esbuild/commit/942815d35542cb21f305dcd1f24d2ce37dd7d5fd, resolves #12.
