### PR TITLE
Load runtime config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ def deps do
 end
 ```
 
-Once installed, change your `config/config.exs` to pick your
-bun version of choice:
+Once installed, change your config (i.e. `config/config.exs` or
+`config/runtime.exs`) to pick your bun version of choice:
 
 ```elixir
 config :bun, version: "1.0.33"
@@ -79,9 +79,7 @@ config :bun,
 ```
 
 When `mix bun default` is invoked, the task arguments will be appended
-to the ones configured above. Note profiles must be configured in your
-`config/config.exs`, as `bun` runs without starting your application
-(and therefore it won't pick settings in `config/runtime.exs`).
+to the ones configured above.
 
 ## Adding to Phoenix
 

--- a/lib/mix/tasks/bun.ex
+++ b/lib/mix/tasks/bun.ex
@@ -13,33 +13,19 @@ defmodule Mix.Tasks.Bun do
   If bun is not installed, it is automatically downloaded.
   Note the arguments given to this task will be appended
   to any configured arguments.
-
-  ## Options
-
-    * `--runtime-config` - load the runtime configuration
-      before executing command
-
-  Note flags to control this Mix task must be given before the
-  profile:
-
-      $ mix bun --runtime-config default assets/js/app.js
-
   """
 
   @shortdoc "Invokes bun with the profile and args"
-
   use Mix.Task
+
+  @requirements ["app.config"]
 
   @impl true
   def run(args) do
-    switches = [runtime_config: :boolean]
-    {opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
+    switches = []
+    {_opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
 
-    if opts[:runtime_config] do
-      Mix.Task.run("app.config")
-    else
-      Application.ensure_all_started(:bun)
-    end
+    Application.ensure_all_started(:bun)
 
     Mix.Task.reenable("bun")
     install_and_run(remaining_args)

--- a/lib/mix/tasks/bun.install.ex
+++ b/lib/mix/tasks/bun.install.ex
@@ -14,9 +14,6 @@ defmodule Mix.Tasks.Bun.Install do
 
   ## Options
 
-      * `--runtime-config` - load the runtime configuration
-        before executing command
-
       * `--if-missing` - install only if the given version
         does not exist
   """
@@ -24,14 +21,14 @@ defmodule Mix.Tasks.Bun.Install do
   @shortdoc "Installs bun under _build"
   use Mix.Task
 
+  @requirements ["app.config"]
+
   @impl true
   def run(args) do
     valid_options = [runtime_config: :boolean, if_missing: :boolean]
 
     case OptionParser.parse_head!(args, strict: valid_options) do
       {opts, []} ->
-        if opts[:runtime_config], do: Mix.Task.run("app.config")
-
         if opts[:if_missing] && latest_version?() do
           :ok
         else
@@ -43,7 +40,6 @@ defmodule Mix.Tasks.Bun.Install do
         Invalid arguments to bun.install, expected one of:
 
             mix bun.install
-            mix bun.install --runtime-config
             mix bun.install --if-missing
         """)
     end


### PR DESCRIPTION
Fixes #17 

This makes it easier to use bun since the end-user can configure bun via either config/config.exs or config/runtime.exs

Loading the runtime config does not cause a big performance hit (and if you want to avoid it then you should probably just call `_build/bun` directly and avoid starting the BEAM at all). But requiring `app.start` _would_ be a big performance hit.