### PR TITLE
Fix docs for typical phoenix setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ alias for deployments, which will also use the `--minify` option:
 
 By default, Phoenix comes with three JS libraries that you'll most likely use in your project: phoenix, phoenix_html and phoenix_live_view.
 
-To tell bun about those libraries you will need to add the following to the `package.json`:
+To tell bun about those libraries you will need to add the following to the `assets/package.json` file:
 
 ```json
 {
   "workspaces": [
-    "deps/*"
+    "../deps/*"
   ],
   "dependencies": {
     "phoenix": "workspace:*",


### PR DESCRIPTION
Just a quick fix to the README, and specifically the Phoenix docs. Since the rest of the README assumes they would `bun add package` inside the "assets/" dir, which would create "assets/package.json" then bun needs to be configured to find the deps directory up one directory, or "../deps". Works like a charm in a new phoenix app.

Thanks for the package! Just replaced esbuild with it.