### PR TITLE
feat: add windows support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,27 +6,28 @@ on:
       - main
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       MIX_ENV: test
     strategy:
       fail-fast: false
       matrix:
-        include:
+        os: [ubuntu-latest, windows-latest]
+        versions:
           - elixir: 1.15.0
             erlang: 24.0.0
           - elixir: 1.16.0
             erlang: 24.0.0
           - elixir: 1.17.0
             erlang: 27.1.0
-    name: Elixir v${{ matrix.elixir }}, Erlang v${{ matrix.erlang }}
+    name: Elixir v${{ matrix.versions.elixir }}, Erlang v${{ matrix.versions.erlang }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{matrix.erlang}}
-          elixir-version: ${{matrix.elixir}}
+          otp-version: ${{matrix.versions.erlang}}
+          elixir-version: ${{matrix.versions.elixir}}
 
       - uses: actions/cache@v3
         with:
@@ -36,6 +37,7 @@ jobs:
       - run: mix deps.get
 
       - run: mix format --check-formatted
+        if: matrix.os != 'windows-latest'
 
       - run: mix deps.unlock --check-unused
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@ import Config
 
 if Mix.env() == :test do
   config :bun,
-    version: "1.1.22",
+    version: "1.1.34",
     another: [
       args: ["--version"]
     ]

--- a/test/bun_test.exs
+++ b/test/bun_test.exs
@@ -16,13 +16,13 @@ defmodule BunTest do
   end
 
   test "updates on install" do
-    Application.put_env(:bun, :version, "1.0.0")
+    Application.put_env(:bun, :version, "1.1.0")
 
     Mix.Task.rerun("bun.install", ["--if-missing"])
 
     assert ExUnit.CaptureIO.capture_io(fn ->
              assert Bun.run(:default, ["--version"]) == 0
-           end) =~ "1.0.0"
+           end) =~ "1.1.0"
 
     Application.delete_env(:bun, :version)
 


### PR DESCRIPTION
Bun is [available for Windows](https://bun.sh/blog/bun-v1.1) since April.