### PR TITLE
Use Bun 1.1.42 by default

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@ import Config
 
 if Mix.env() == :test do
   config :bun,
-    version: "1.1.34",
+    version: "1.1.42",
     another: [
       args: ["--version"]
     ]

--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -1,6 +1,6 @@
 defmodule Bun do
   # https://github.com/oven-sh/bun/releases
-  @latest_version "1.1.34"
+  @latest_version "1.1.42"
   @min_windows_version "1.1.0"
 
   @moduledoc """


### PR DESCRIPTION
Update the default Bun version to 1.1.42, which is the latest one at this moment.