### PR TITLE
Support musl distros

### DIFF
--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -245,15 +245,22 @@ defmodule Bun do
 
       {:unix, osname} ->
         arch_str = :erlang.system_info(:system_architecture)
-        [arch | _] = arch_str |> List.to_string() |> String.split("-")
+        [arch | other] = arch_str |> List.to_string() |> String.split("-")
 
-        case arch do
-          "amd64" -> "#{osname}-x64"
-          "x86_64" -> "#{osname}-x64"
-          "i686" -> "#{osname}-ia32"
-          "i386" -> "#{osname}-ia32"
-          "aarch64" -> "#{osname}-aarch64"
-          _ -> raise "bun is not available for architecture: #{arch_str}"
+        target =
+          case arch do
+            "amd64" -> "#{osname}-x64"
+            "x86_64" -> "#{osname}-x64"
+            "i686" -> "#{osname}-ia32"
+            "i386" -> "#{osname}-ia32"
+            "aarch64" -> "#{osname}-aarch64"
+            _ -> raise "bun is not available for architecture: #{arch_str}"
+          end
+
+        if Enum.any?(other, &(&1 == "musl")) do
+          target <> "-musl"
+        else
+          target
         end
     end
   end

--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -257,11 +257,9 @@ defmodule Bun do
             _ -> raise "bun is not available for architecture: #{arch_str}"
           end
 
-        if Enum.any?(other, &(&1 == "musl")) do
-          target <> "-musl"
-        else
-          target
-        end
+        if Enum.any?(other, &(&1 == "musl")),
+          do: target <> "-musl",
+          else: target
     end
   end
 


### PR DESCRIPTION
This change adds support for musl-based distros (like Alpine) to download the binary ready to use that library.

It allows, at the time of writing this, to use this library building a Docker image using Alpine 3.20.0