### PR TITLE
Relax Erlang versions in GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         versions:
           - elixir: 1.15.0
-            erlang: 24.0.0
+            erlang: 24.0
           - elixir: 1.16.0
-            erlang: 24.0.0
+            erlang: 24.0
           - elixir: 1.17.0
-            erlang: 27.1.0
+            erlang: 27.1
           - elixir: 1.18.0
-            erlang: 27.2.0
+            erlang: 27.2
     name: Elixir v${{ matrix.versions.elixir }}, Erlang v${{ matrix.versions.erlang }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the following error in the CI pipeline:

```
Run erlef/setup-beam@v1
  with:
    otp-version: [2](https://github.com/crbelaus/bun/actions/runs/13310866180/job/37172835065#step:3:2)4.0.0
    elixir-version: 1.15.0
    github-token: ***
    install-hex: true
    install-rebar: true
    version-type: loose
    disable_problem_matchers: false
    hexpm-mirrors: https://builds.hex.pm
  
  env:
    MIX_ENV: test
Error: Requested Erlang/OTP version (2[4](https://github.com/crbelaus/bun/actions/runs/13310866180/job/37172835065#step:3:4).0.0) not found in version list (should you be using option 'version-type': 'strict'?)
```