### PR TITLE
Forward stdin

### DIFF
--- a/priv/wrapper.js
+++ b/priv/wrapper.js
@@ -3,6 +3,7 @@ const command = process.argv.slice(2)
 const sub = Bun.spawn(command, {
   stdout: 'inherit',
   stderr: 'inherit',
+  stdin: Bun.stdin.stream(),
   onExit: (_, code) => process.exit(code)
 })
 


### PR DESCRIPTION
I haven't extensively tested this, but it seems to work for my usecase.

The problem was that I made vite handle stdin closing by itself (for nodejs) and then the wrapper would make the process close immediately. This should work no matter if the started process handles stdin closes by itself.