### PR TITLE
Revert load runtime config by default and reintroduced runtime config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ def deps do
 end
 ```
 
-Once installed, change your config (i.e. `config/config.exs` or
-`config/runtime.exs`) to pick your bun version of choice:
+Once installed, change your `config/config.exs` to pick your
+bun version of choice:
 
 ```elixir
 config :bun, version: "1.1.22"

--- a/lib/mix/tasks/bun.ex
+++ b/lib/mix/tasks/bun.ex
@@ -13,19 +13,33 @@ defmodule Mix.Tasks.Bun do
   If bun is not installed, it is automatically downloaded.
   Note the arguments given to this task will be appended
   to any configured arguments.
+
+  ## Options
+
+    * `--runtime-config` - load the runtime configuration
+      before executing command
+
+  Note flags to control this Mix task must be given before the
+  profile:
+
+      $ mix bun --runtime-config default assets/js/app.js
+
   """
 
   @shortdoc "Invokes bun with the profile and args"
-  use Mix.Task
 
-  @requirements ["app.config"]
+  use Mix.Task
 
   @impl true
   def run(args) do
-    switches = []
-    {_opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
+    switches = [runtime_config: :boolean]
+    {opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
 
-    Application.ensure_all_started(:bun)
+    if opts[:runtime_config] do
+      Mix.Task.run("app.config")
+    else
+      Application.ensure_all_started(:bun)
+    end
 
     Mix.Task.reenable("bun")
     install_and_run(remaining_args)

--- a/lib/mix/tasks/bun.install.ex
+++ b/lib/mix/tasks/bun.install.ex
@@ -14,6 +14,9 @@ defmodule Mix.Tasks.Bun.Install do
 
   ## Options
 
+      * `--runtime-config` - load the runtime configuration
+        before executing command
+
       * `--if-missing` - install only if the given version
         does not exist
   """
@@ -21,14 +24,14 @@ defmodule Mix.Tasks.Bun.Install do
   @shortdoc "Installs bun under _build"
   use Mix.Task
 
-  @requirements ["app.config"]
-
   @impl true
   def run(args) do
     valid_options = [runtime_config: :boolean, if_missing: :boolean]
 
     case OptionParser.parse_head!(args, strict: valid_options) do
       {opts, []} ->
+        if opts[:runtime_config], do: Mix.Task.run("app.config")
+
         if opts[:if_missing] && latest_version?() do
           :ok
         else
@@ -40,6 +43,7 @@ defmodule Mix.Tasks.Bun.Install do
         Invalid arguments to bun.install, expected one of:
 
             mix bun.install
+            mix bun.install --runtime-config
             mix bun.install --if-missing
         """)
     end


### PR DESCRIPTION
This fixes the long-standing discussion in #39. 

This PR reverts 9645ccda00392e28ef78383fcad2d0a83c95662c and reintroduces the `--runtime-config` flag to the configuration at runtime when the flag is set. 

I would like to let you know that this is a breaking change, as the behaviour of how configuration is loaded has changed.

